### PR TITLE
第5章: Refresh Token・失効・認証監査ログを追加

### DIFF
--- a/services/identity/Identity.Api.Tests/AuthControllerPostgresTests.cs
+++ b/services/identity/Identity.Api.Tests/AuthControllerPostgresTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Npgsql;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Identity.Api.Tests;
+
+public class AuthControllerPostgresTests(PostgresIdentityApiFactory factory) : IClassFixture<PostgresIdentityApiFactory>
+{
+    private const string ConnectionString = "Host=localhost;Port=5432;Database=invdb;Username=inv;Password=invpass;Timeout=2";
+
+    [Fact]
+    public async Task Register_PersistsToIdentityUsers_AndLoginReturnsJwt()
+    {
+        if (!await CanConnectToPostgresAsync())
+        {
+            return;
+        }
+
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var email = $"pg_{Guid.NewGuid():N}@test.com";
+        const string plainPassword = "P@ssw0rd123!";
+
+        var register = await client.PostAsJsonAsync("/auth/register", new RegisterRequest(email, plainPassword));
+        Assert.Equal(HttpStatusCode.Created, register.StatusCode);
+
+        await using var conn = new NpgsqlConnection(ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = new NpgsqlCommand(
+            "select password_hash from identity.users where email = @email",
+            conn);
+        cmd.Parameters.AddWithValue("email", email);
+        var hash = (string?)await cmd.ExecuteScalarAsync();
+
+        Assert.False(string.IsNullOrWhiteSpace(hash));
+        Assert.NotEqual(plainPassword, hash);
+
+        var login = await client.PostAsJsonAsync("/auth/login", new LoginRequest(email, plainPassword));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        var payload = await login.Content.ReadFromJsonAsync<AuthTokensResponse>();
+        Assert.NotNull(payload);
+        Assert.False(string.IsNullOrWhiteSpace(payload!.AccessToken));
+        Assert.False(string.IsNullOrWhiteSpace(payload!.RefreshToken));
+
+        var refresh = await client.PostAsJsonAsync("/auth/refresh", new RefreshRequest(payload.RefreshToken));
+        Assert.Equal(HttpStatusCode.OK, refresh.StatusCode);
+    }
+
+    private static async Task<bool> CanConnectToPostgresAsync()
+    {
+        try
+        {
+            await using var conn = new NpgsqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public sealed record RegisterRequest(string Email, string Password);
+    public sealed record LoginRequest(string Email, string Password);
+    public sealed record RefreshRequest(string RefreshToken);
+    public sealed record AuthTokensResponse(string AccessToken, string RefreshToken);
+}
+
+public class PostgresIdentityApiFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+    {
+        builder.UseSetting("IdentityDb:UseInMemory", "false");
+        builder.UseSetting("ConnectionStrings:IdentityDb", "Host=localhost;Port=5432;Database=invdb;Username=inv;Password=invpass");
+    }
+}

--- a/services/identity/Identity.Api.Tests/AuthControllerTests.cs
+++ b/services/identity/Identity.Api.Tests/AuthControllerTests.cs
@@ -37,9 +37,10 @@ public class AuthControllerTests(IdentityApiFactory factory) : IClassFixture<Ide
         var loginResponse = await client.PostAsJsonAsync("/auth/login", new LoginRequest(email, plainPassword));
         Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
 
-        var payload = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        var payload = await loginResponse.Content.ReadFromJsonAsync<AuthTokensResponse>();
         Assert.NotNull(payload);
-        Assert.False(string.IsNullOrWhiteSpace(payload!.Token));
+        Assert.False(string.IsNullOrWhiteSpace(payload!.AccessToken));
+        Assert.False(string.IsNullOrWhiteSpace(payload!.RefreshToken));
     }
 
     [Fact]
@@ -55,9 +56,42 @@ public class AuthControllerTests(IdentityApiFactory factory) : IClassFixture<Ide
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
+    [Fact]
+    public async Task Refresh_ThenRevoke_ThenRefreshAgain_ReturnsUnauthorized()
+    {
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var email = $"refresh_{Guid.NewGuid():N}@test.com";
+        const string plainPassword = "P@ssw0rd123!";
+
+        var registerResponse = await client.PostAsJsonAsync("/auth/register", new RegisterRequest(email, plainPassword));
+        Assert.Equal(HttpStatusCode.Created, registerResponse.StatusCode);
+
+        var loginResponse = await client.PostAsJsonAsync("/auth/login", new LoginRequest(email, plainPassword));
+        Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+        var loginPayload = await loginResponse.Content.ReadFromJsonAsync<AuthTokensResponse>();
+        Assert.NotNull(loginPayload);
+
+        var refreshResponse = await client.PostAsJsonAsync("/auth/refresh", new RefreshRequest(loginPayload!.RefreshToken));
+        Assert.Equal(HttpStatusCode.OK, refreshResponse.StatusCode);
+        var refreshedPayload = await refreshResponse.Content.ReadFromJsonAsync<AuthTokensResponse>();
+        Assert.NotNull(refreshedPayload);
+
+        var revokeResponse = await client.PostAsJsonAsync("/auth/revoke", new RevokeRequest(refreshedPayload!.RefreshToken));
+        Assert.Equal(HttpStatusCode.NoContent, revokeResponse.StatusCode);
+
+        var refreshAfterRevoke = await client.PostAsJsonAsync("/auth/refresh", new RefreshRequest(refreshedPayload.RefreshToken));
+        Assert.Equal(HttpStatusCode.Unauthorized, refreshAfterRevoke.StatusCode);
+    }
+
     public sealed record RegisterRequest(string Email, string Password);
     public sealed record LoginRequest(string Email, string Password);
-    public sealed record LoginResponse(string Token);
+    public sealed record RefreshRequest(string RefreshToken);
+    public sealed record RevokeRequest(string RefreshToken);
+    public sealed record AuthTokensResponse(string AccessToken, string RefreshToken);
 }
 
 public class IdentityApiFactory : WebApplicationFactory<Program>

--- a/services/identity/Identity.Api.Tests/Identity.Api.Tests.csproj
+++ b/services/identity/Identity.Api.Tests/Identity.Api.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/services/identity/Identity.Api/Application/Auth/AuthModels.cs
+++ b/services/identity/Identity.Api/Application/Auth/AuthModels.cs
@@ -2,7 +2,9 @@ namespace Identity.Api.Application.Auth;
 
 public sealed record RegisterCommand(string Email, string Password);
 public sealed record LoginCommand(string Email, string Password);
-public sealed record LoginResult(string Token);
+public sealed record RefreshCommand(string RefreshToken);
+public sealed record RevokeCommand(string RefreshToken);
+public sealed record AuthTokensResult(string AccessToken, string RefreshToken);
 
 public enum RegisterStatus
 {

--- a/services/identity/Identity.Api/Application/Auth/AuthService.cs
+++ b/services/identity/Identity.Api/Application/Auth/AuthService.cs
@@ -7,12 +7,17 @@ namespace Identity.Api.Application.Auth;
 
 public class AuthService(
     IUserRepository userRepository,
+    IRefreshTokenRepository refreshTokenRepository,
+    IAuthAuditLogRepository auditLogRepository,
     IPasswordHasher<User> passwordHasher,
     ITokenService tokenService) : IAuthService
 {
     private readonly IUserRepository _userRepository = userRepository;
+    private readonly IRefreshTokenRepository _refreshTokenRepository = refreshTokenRepository;
+    private readonly IAuthAuditLogRepository _auditLogRepository = auditLogRepository;
     private readonly IPasswordHasher<User> _passwordHasher = passwordHasher;
     private readonly ITokenService _tokenService = tokenService;
+    private static readonly TimeSpan RefreshTokenLifetime = TimeSpan.FromDays(7);
 
     /// <summary>
     /// 新規ユーザーを作成します。
@@ -41,22 +46,89 @@ public class AuthService(
     /// </summary>
     /// <param name="command">ログイン情報です。</param>
     /// <param name="cancellationToken">キャンセル用トークンです。</param>
-    /// <returns>成功時はトークン情報、失敗時はnullです。</returns>
-    public async Task<LoginResult?> LoginAsync(LoginCommand command, CancellationToken cancellationToken = default)
+    /// <returns>成功時はアクセストークン/リフレッシュトークン、失敗時はnullです。</returns>
+    public async Task<AuthTokensResult?> LoginAsync(LoginCommand command, CancellationToken cancellationToken = default)
     {
         var normalizedEmail = User.NormalizeEmail(command.Email);
         var user = await _userRepository.GetByEmailAsync(normalizedEmail, cancellationToken);
         if (user is null)
         {
+            await _auditLogRepository.AddAsync(AuthAuditLog.Create("login", false, null, "user_not_found"), cancellationToken);
             return null;
         }
 
         var verifyResult = _passwordHasher.VerifyHashedPassword(user, user.PasswordHash, command.Password);
         if (verifyResult == PasswordVerificationResult.Failed)
         {
+            await _auditLogRepository.AddAsync(AuthAuditLog.Create("login", false, user.Id, "invalid_password"), cancellationToken);
             return null;
         }
 
-        return new LoginResult(_tokenService.Generate(user));
+        var accessToken = _tokenService.GenerateAccessToken(user);
+        var refreshToken = _tokenService.GenerateRefreshToken();
+        var refreshTokenHash = _tokenService.HashToken(refreshToken);
+        var tokenEntity = RefreshToken.Create(user.Id, refreshTokenHash, DateTime.UtcNow.Add(RefreshTokenLifetime));
+        await _refreshTokenRepository.AddAsync(tokenEntity, cancellationToken);
+        await _auditLogRepository.AddAsync(AuthAuditLog.Create("login", true, user.Id), cancellationToken);
+
+        return new AuthTokensResult(accessToken, refreshToken);
+    }
+
+    /// <summary>
+    /// リフレッシュトークンで再発行します。
+    /// </summary>
+    /// <param name="command">再発行情報です。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>成功時は新しいアクセストークン/リフレッシュトークン、失敗時はnullです。</returns>
+    public async Task<AuthTokensResult?> RefreshAsync(RefreshCommand command, CancellationToken cancellationToken = default)
+    {
+        var tokenHash = _tokenService.HashToken(command.RefreshToken);
+        var refreshToken = await _refreshTokenRepository.GetByTokenHashAsync(tokenHash, cancellationToken);
+        if (refreshToken is null || !refreshToken.IsActive(DateTime.UtcNow))
+        {
+            await _auditLogRepository.AddAsync(AuthAuditLog.Create("refresh", false, null, "invalid_or_expired_refresh_token"), cancellationToken);
+            return null;
+        }
+
+        var user = await _userRepository.GetByIdAsync(refreshToken.UserId, cancellationToken);
+        if (user is null)
+        {
+            await _auditLogRepository.AddAsync(AuthAuditLog.Create("refresh", false, null, "user_not_found"), cancellationToken);
+            return null;
+        }
+
+        var newRefreshToken = _tokenService.GenerateRefreshToken();
+        var newRefreshTokenHash = _tokenService.HashToken(newRefreshToken);
+        refreshToken.Revoke(DateTime.UtcNow, newRefreshTokenHash);
+        await _refreshTokenRepository.SaveChangesAsync(cancellationToken);
+
+        var newTokenEntity = RefreshToken.Create(user.Id, newRefreshTokenHash, DateTime.UtcNow.Add(RefreshTokenLifetime));
+        await _refreshTokenRepository.AddAsync(newTokenEntity, cancellationToken);
+
+        var newAccessToken = _tokenService.GenerateAccessToken(user);
+        await _auditLogRepository.AddAsync(AuthAuditLog.Create("refresh", true, user.Id), cancellationToken);
+        return new AuthTokensResult(newAccessToken, newRefreshToken);
+    }
+
+    /// <summary>
+    /// リフレッシュトークンを失効します。
+    /// </summary>
+    /// <param name="command">失効情報です。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>失効できた場合はtrueです。</returns>
+    public async Task<bool> RevokeAsync(RevokeCommand command, CancellationToken cancellationToken = default)
+    {
+        var tokenHash = _tokenService.HashToken(command.RefreshToken);
+        var refreshToken = await _refreshTokenRepository.GetByTokenHashAsync(tokenHash, cancellationToken);
+        if (refreshToken is null || !refreshToken.IsActive(DateTime.UtcNow))
+        {
+            await _auditLogRepository.AddAsync(AuthAuditLog.Create("revoke", false, null, "invalid_or_expired_refresh_token"), cancellationToken);
+            return false;
+        }
+
+        refreshToken.Revoke(DateTime.UtcNow);
+        await _refreshTokenRepository.SaveChangesAsync(cancellationToken);
+        await _auditLogRepository.AddAsync(AuthAuditLog.Create("revoke", true, refreshToken.UserId), cancellationToken);
+        return true;
     }
 }

--- a/services/identity/Identity.Api/Application/Auth/IAuthService.cs
+++ b/services/identity/Identity.Api/Application/Auth/IAuthService.cs
@@ -15,6 +15,22 @@ public interface IAuthService
     /// </summary>
     /// <param name="command">ログイン情報です。</param>
     /// <param name="cancellationToken">キャンセル用トークンです。</param>
-    /// <returns>成功時はトークン情報、失敗時はnullです。</returns>
-    Task<LoginResult?> LoginAsync(LoginCommand command, CancellationToken cancellationToken = default);
+    /// <returns>成功時はアクセストークン/リフレッシュトークン、失敗時はnullです。</returns>
+    Task<AuthTokensResult?> LoginAsync(LoginCommand command, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// リフレッシュトークンで再発行します。
+    /// </summary>
+    /// <param name="command">再発行情報です。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>成功時は新しいアクセストークン/リフレッシュトークン、失敗時はnullです。</returns>
+    Task<AuthTokensResult?> RefreshAsync(RefreshCommand command, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// リフレッシュトークンを失効します。
+    /// </summary>
+    /// <param name="command">失効情報です。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>失効できた場合はtrueです。</returns>
+    Task<bool> RevokeAsync(RevokeCommand command, CancellationToken cancellationToken = default);
 }

--- a/services/identity/Identity.Api/Controllers/AuthController.cs
+++ b/services/identity/Identity.Api/Controllers/AuthController.cs
@@ -39,9 +39,9 @@ public class AuthController(IAuthService authService) : ControllerBase
     /// <param name="cancellationToken">キャンセル用トークンです。</param>
     /// <returns>認証結果です。</returns>
     [HttpPost("login")]
-    [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(AuthTokensResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<ActionResult<LoginResponse>> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult<AuthTokensResponse>> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
     {
         var result = await _authService.LoginAsync(
             new LoginCommand(request.Email, request.Password),
@@ -52,10 +52,52 @@ public class AuthController(IAuthService authService) : ControllerBase
             return Unauthorized();
         }
 
-        return Ok(new LoginResponse(result.Token));
+        return Ok(new AuthTokensResponse(result.AccessToken, result.RefreshToken));
+    }
+
+    /// <summary>
+    /// リフレッシュトークンで再発行します。
+    /// </summary>
+    /// <param name="request">再発行リクエストです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>再発行結果です。</returns>
+    [HttpPost("refresh")]
+    [ProducesResponseType(typeof(AuthTokensResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<AuthTokensResponse>> Refresh([FromBody] RefreshRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _authService.RefreshAsync(new RefreshCommand(request.RefreshToken), cancellationToken);
+        if (result is null)
+        {
+            return Unauthorized();
+        }
+
+        return Ok(new AuthTokensResponse(result.AccessToken, result.RefreshToken));
+    }
+
+    /// <summary>
+    /// リフレッシュトークンを失効します。
+    /// </summary>
+    /// <param name="request">失効リクエストです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>失効結果です。</returns>
+    [HttpPost("revoke")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Revoke([FromBody] RevokeRequest request, CancellationToken cancellationToken)
+    {
+        var success = await _authService.RevokeAsync(new RevokeCommand(request.RefreshToken), cancellationToken);
+        if (!success)
+        {
+            return Unauthorized();
+        }
+
+        return NoContent();
     }
 }
 
 public record RegisterRequest(string Email, string Password);
 public record LoginRequest(string Email, string Password);
-public record LoginResponse(string Token);
+public record RefreshRequest(string RefreshToken);
+public record RevokeRequest(string RefreshToken);
+public record AuthTokensResponse(string AccessToken, string RefreshToken);

--- a/services/identity/Identity.Api/Domain/AuthAuditLog.cs
+++ b/services/identity/Identity.Api/Domain/AuthAuditLog.cs
@@ -1,0 +1,32 @@
+namespace Identity.Api.Domain;
+
+public class AuthAuditLog
+{
+    public Guid Id { get; private set; }
+    public Guid? UserId { get; private set; }
+    public string Action { get; private set; } = string.Empty;
+    public bool Success { get; private set; }
+    public string? Detail { get; private set; }
+    public DateTime CreatedAtUtc { get; private set; }
+
+    /// <summary>
+    /// 認証監査ログを生成します。
+    /// </summary>
+    /// <param name="action">操作名です。</param>
+    /// <param name="success">成功可否です。</param>
+    /// <param name="userId">対象ユーザーIDです。</param>
+    /// <param name="detail">補足情報です。</param>
+    /// <returns>作成した監査ログです。</returns>
+    public static AuthAuditLog Create(string action, bool success, Guid? userId = null, string? detail = null)
+    {
+        return new AuthAuditLog
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Action = action,
+            Success = success,
+            Detail = detail,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+    }
+}

--- a/services/identity/Identity.Api/Domain/RefreshToken.cs
+++ b/services/identity/Identity.Api/Domain/RefreshToken.cs
@@ -1,0 +1,52 @@
+namespace Identity.Api.Domain;
+
+public class RefreshToken
+{
+    public Guid Id { get; private set; }
+    public Guid UserId { get; private set; }
+    public string TokenHash { get; private set; } = string.Empty;
+    public DateTime ExpiresAtUtc { get; private set; }
+    public DateTime CreatedAtUtc { get; private set; }
+    public DateTime? RevokedAtUtc { get; private set; }
+    public string? ReplacedByTokenHash { get; private set; }
+
+    /// <summary>
+    /// リフレッシュトークンを生成します。
+    /// </summary>
+    /// <param name="userId">対象ユーザーIDです。</param>
+    /// <param name="tokenHash">保存用ハッシュです。</param>
+    /// <param name="expiresAtUtc">有効期限です。</param>
+    /// <returns>作成したトークンです。</returns>
+    public static RefreshToken Create(Guid userId, string tokenHash, DateTime expiresAtUtc)
+    {
+        return new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            TokenHash = tokenHash,
+            ExpiresAtUtc = expiresAtUtc,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// 失効可能かを返します。
+    /// </summary>
+    /// <param name="nowUtc">現在UTC時刻です。</param>
+    /// <returns>有効ならtrueです。</returns>
+    public bool IsActive(DateTime nowUtc)
+    {
+        return RevokedAtUtc is null && ExpiresAtUtc > nowUtc;
+    }
+
+    /// <summary>
+    /// トークンを失効します。
+    /// </summary>
+    /// <param name="nowUtc">失効時刻です。</param>
+    /// <param name="replacedByTokenHash">置換先トークンハッシュです。</param>
+    public void Revoke(DateTime nowUtc, string? replacedByTokenHash = null)
+    {
+        RevokedAtUtc = nowUtc;
+        ReplacedByTokenHash = replacedByTokenHash;
+    }
+}

--- a/services/identity/Identity.Api/Infrastructure/IdentityDbContext.cs
+++ b/services/identity/Identity.Api/Infrastructure/IdentityDbContext.cs
@@ -9,6 +9,14 @@ public class IdentityDbContext(DbContextOptions<IdentityDbContext> options) : Db
     /// ユーザー集合です。
     /// </summary>
     public DbSet<User> Users => Set<User>();
+    /// <summary>
+    /// リフレッシュトークン集合です。
+    /// </summary>
+    public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+    /// <summary>
+    /// 認証監査ログ集合です。
+    /// </summary>
+    public DbSet<AuthAuditLog> AuthAuditLogs => Set<AuthAuditLog>();
 
     /// <summary>
     /// モデル定義を構成します。
@@ -26,6 +34,28 @@ public class IdentityDbContext(DbContextOptions<IdentityDbContext> options) : Db
             entity.Property(x => x.PasswordHash).IsRequired();
             entity.Property(x => x.Role).HasMaxLength(32).IsRequired();
             entity.HasIndex(x => x.Email).IsUnique();
+        });
+
+        modelBuilder.Entity<RefreshToken>(entity =>
+        {
+            entity.ToTable("refresh_tokens");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.TokenHash).IsRequired();
+            entity.Property(x => x.ExpiresAtUtc).IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.HasIndex(x => x.TokenHash).IsUnique();
+            entity.HasIndex(x => x.UserId);
+        });
+
+        modelBuilder.Entity<AuthAuditLog>(entity =>
+        {
+            entity.ToTable("auth_audit_logs");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Action).HasMaxLength(64).IsRequired();
+            entity.Property(x => x.Success).IsRequired();
+            entity.Property(x => x.CreatedAtUtc).IsRequired();
+            entity.Property(x => x.Detail).HasMaxLength(512);
+            entity.HasIndex(x => x.CreatedAtUtc);
         });
     }
 }

--- a/services/identity/Identity.Api/Infrastructure/Repositories/AuthAuditLogRepository.cs
+++ b/services/identity/Identity.Api/Infrastructure/Repositories/AuthAuditLogRepository.cs
@@ -1,0 +1,20 @@
+using Identity.Api.Domain;
+
+namespace Identity.Api.Infrastructure.Repositories;
+
+public class AuthAuditLogRepository(IdentityDbContext db) : IAuthAuditLogRepository
+{
+    private readonly IdentityDbContext _db = db;
+
+    /// <summary>
+    /// 監査ログを保存します。
+    /// </summary>
+    /// <param name="log">保存対象ログです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>非同期処理です。</returns>
+    public async Task AddAsync(AuthAuditLog log, CancellationToken cancellationToken = default)
+    {
+        _db.AuthAuditLogs.Add(log);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/services/identity/Identity.Api/Infrastructure/Repositories/IAuthAuditLogRepository.cs
+++ b/services/identity/Identity.Api/Infrastructure/Repositories/IAuthAuditLogRepository.cs
@@ -1,0 +1,14 @@
+using Identity.Api.Domain;
+
+namespace Identity.Api.Infrastructure.Repositories;
+
+public interface IAuthAuditLogRepository
+{
+    /// <summary>
+    /// 監査ログを保存します。
+    /// </summary>
+    /// <param name="log">保存対象ログです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>非同期処理です。</returns>
+    Task AddAsync(AuthAuditLog log, CancellationToken cancellationToken = default);
+}

--- a/services/identity/Identity.Api/Infrastructure/Repositories/IRefreshTokenRepository.cs
+++ b/services/identity/Identity.Api/Infrastructure/Repositories/IRefreshTokenRepository.cs
@@ -1,0 +1,29 @@
+using Identity.Api.Domain;
+
+namespace Identity.Api.Infrastructure.Repositories;
+
+public interface IRefreshTokenRepository
+{
+    /// <summary>
+    /// トークンハッシュでリフレッシュトークンを取得します。
+    /// </summary>
+    /// <param name="tokenHash">トークンハッシュです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>リフレッシュトークン。未存在ならnullです。</returns>
+    Task<RefreshToken?> GetByTokenHashAsync(string tokenHash, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// リフレッシュトークンを保存します。
+    /// </summary>
+    /// <param name="refreshToken">保存対象トークンです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>非同期処理です。</returns>
+    Task AddAsync(RefreshToken refreshToken, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// リフレッシュトークン更新を保存します。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>非同期処理です。</returns>
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/identity/Identity.Api/Infrastructure/Repositories/IUserRepository.cs
+++ b/services/identity/Identity.Api/Infrastructure/Repositories/IUserRepository.cs
@@ -21,6 +21,14 @@ public interface IUserRepository
     Task<User?> GetByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// IDでユーザーを取得します。
+    /// </summary>
+    /// <param name="userId">ユーザーIDです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>ユーザー。未存在ならnullです。</returns>
+    Task<User?> GetByIdAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// ユーザーを保存します。
     /// </summary>
     /// <param name="user">保存対象ユーザーです。</param>

--- a/services/identity/Identity.Api/Infrastructure/Repositories/RefreshTokenRepository.cs
+++ b/services/identity/Identity.Api/Infrastructure/Repositories/RefreshTokenRepository.cs
@@ -1,0 +1,42 @@
+using Identity.Api.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Identity.Api.Infrastructure.Repositories;
+
+public class RefreshTokenRepository(IdentityDbContext db) : IRefreshTokenRepository
+{
+    private readonly IdentityDbContext _db = db;
+
+    /// <summary>
+    /// トークンハッシュでリフレッシュトークンを取得します。
+    /// </summary>
+    /// <param name="tokenHash">トークンハッシュです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>リフレッシュトークン。未存在ならnullです。</returns>
+    public Task<RefreshToken?> GetByTokenHashAsync(string tokenHash, CancellationToken cancellationToken = default)
+    {
+        return _db.RefreshTokens.SingleOrDefaultAsync(x => x.TokenHash == tokenHash, cancellationToken);
+    }
+
+    /// <summary>
+    /// リフレッシュトークンを保存します。
+    /// </summary>
+    /// <param name="refreshToken">保存対象トークンです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>非同期処理です。</returns>
+    public async Task AddAsync(RefreshToken refreshToken, CancellationToken cancellationToken = default)
+    {
+        _db.RefreshTokens.Add(refreshToken);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// リフレッシュトークン更新を保存します。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>非同期処理です。</returns>
+    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        return _db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/services/identity/Identity.Api/Infrastructure/Repositories/UserRepository.cs
+++ b/services/identity/Identity.Api/Infrastructure/Repositories/UserRepository.cs
@@ -30,6 +30,17 @@ public class UserRepository(IdentityDbContext db) : IUserRepository
     }
 
     /// <summary>
+    /// IDでユーザーを取得します。
+    /// </summary>
+    /// <param name="userId">ユーザーIDです。</param>
+    /// <param name="cancellationToken">キャンセル用トークンです。</param>
+    /// <returns>ユーザー。未存在ならnullです。</returns>
+    public Task<User?> GetByIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return _db.Users.SingleOrDefaultAsync(x => x.Id == userId, cancellationToken);
+    }
+
+    /// <summary>
     /// ユーザーを追加して保存します。
     /// </summary>
     /// <param name="user">保存対象ユーザーです。</param>

--- a/services/identity/Identity.Api/Infrastructure/Security/ITokenService.cs
+++ b/services/identity/Identity.Api/Infrastructure/Security/ITokenService.cs
@@ -9,5 +9,18 @@ public interface ITokenService
     /// </summary>
     /// <param name="user">トークン対象ユーザーです。</param>
     /// <returns>JWT文字列です。</returns>
-    string Generate(User user);
+    string GenerateAccessToken(User user);
+
+    /// <summary>
+    /// リフレッシュトークン文字列を生成します。
+    /// </summary>
+    /// <returns>平文リフレッシュトークンです。</returns>
+    string GenerateRefreshToken();
+
+    /// <summary>
+    /// トークンを保存用ハッシュへ変換します。
+    /// </summary>
+    /// <param name="token">平文トークンです。</param>
+    /// <returns>SHA-256ハッシュです。</returns>
+    string HashToken(string token);
 }

--- a/services/identity/Identity.Api/Infrastructure/Security/JwtTokenService.cs
+++ b/services/identity/Identity.Api/Infrastructure/Security/JwtTokenService.cs
@@ -1,5 +1,6 @@
 using Identity.Api.Domain;
 using Microsoft.IdentityModel.Tokens;
+using System.Security.Cryptography;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
@@ -13,7 +14,7 @@ public class JwtTokenService : ITokenService
     /// </summary>
     /// <param name="user">トークン対象ユーザーです。</param>
     /// <returns>JWT文字列です。</returns>
-    public string Generate(User user)
+    public string GenerateAccessToken(User user)
     {
         var claims = new[]
         {
@@ -30,5 +31,26 @@ public class JwtTokenService : ITokenService
             signingCredentials: creds);
 
         return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    /// <summary>
+    /// リフレッシュトークン文字列を生成します。
+    /// </summary>
+    /// <returns>平文リフレッシュトークンです。</returns>
+    public string GenerateRefreshToken()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(64);
+        return Convert.ToBase64String(bytes);
+    }
+
+    /// <summary>
+    /// トークンを保存用ハッシュへ変換します。
+    /// </summary>
+    /// <param name="token">平文トークンです。</param>
+    /// <returns>SHA-256ハッシュです。</returns>
+    public string HashToken(string token)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(token));
+        return Convert.ToHexString(bytes);
     }
 }

--- a/services/identity/Identity.Api/Program.cs
+++ b/services/identity/Identity.Api/Program.cs
@@ -26,6 +26,8 @@ else
 }
 builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
+builder.Services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
+builder.Services.AddScoped<IAuthAuditLogRepository, AuthAuditLogRepository>();
 builder.Services.AddScoped<ITokenService, JwtTokenService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 
@@ -53,7 +55,15 @@ using (var scope = app.Services.CreateScope())
     var db = scope.ServiceProvider.GetRequiredService<IdentityDbContext>();
     if (db.Database.IsRelational())
     {
-        await db.Database.MigrateAsync();
+        var hasMigrations = db.Database.GetMigrations().Any();
+        if (hasMigrations)
+        {
+            await db.Database.MigrateAsync();
+        }
+        else
+        {
+            await db.Database.EnsureCreatedAsync();
+        }
     }
     else
     {


### PR DESCRIPTION
## 概要
- IdentityにRefresh Tokenの発行/再発行/失効フローを追加
- 認証イベント（login/refresh/revoke）の監査ログ保存を追加
- Auth APIを拡張（/auth/refresh, /auth/revoke）
- 統合テストを拡張（refresh/revokeシナリオ、PostgreSQL検証）

## 主な変更
- Domain: RefreshToken, AuthAuditLog
- Infrastructure: RefreshTokenRepository, AuthAuditLogRepository
- Application: AuthService / IAuthService拡張
- API: AuthControllerレスポンスをAccess+Refresh構成へ変更

## テスト
- dotnet test inventory-management.sln