### PR TITLE
第13章: 注文履歴と注文状態表示を追加

### DIFF
--- a/apps/web/e2e/orders.spec.ts
+++ b/apps/web/e2e/orders.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test"
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("inventory.jwt", "e2e-dummy-token")
+  })
+})
+
+test("orders page shows history and detail with status labels", async ({ page }) => {
+  await page.route("**://localhost:5003/orders", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "3d6f0d63-2f9a-4f27-b25b-53bc41f04001",
+          userId: "2",
+          status: "accepted",
+          createdAtUtc: "2026-02-27T10:00:00Z",
+          updatedAtUtc: "2026-02-27T10:00:00Z",
+          items: [{ productId: "f4458e4c-9f68-45ea-9052-7f21b6771001", quantity: 2 }],
+        },
+      ]),
+    })
+  })
+
+  await page.route("**://localhost:5003/orders/3d6f0d63-2f9a-4f27-b25b-53bc41f04001", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "3d6f0d63-2f9a-4f27-b25b-53bc41f04001",
+        userId: "2",
+        status: "shipped",
+        createdAtUtc: "2026-02-27T10:00:00Z",
+        updatedAtUtc: "2026-02-27T11:00:00Z",
+        items: [{ productId: "f4458e4c-9f68-45ea-9052-7f21b6771001", quantity: 2 }],
+      }),
+    })
+  })
+
+  await page.goto("/orders")
+  await expect(page.getByRole("heading", { name: "注文履歴" })).toBeVisible()
+  await expect(page.getByText("受付")).toBeVisible()
+  await page.getByRole("button", { name: "詳細を表示" }).click()
+  await expect(page.getByText("ステータス")).toBeVisible()
+  await expect(page.getByText("出荷")).toBeVisible()
+})
+
+test("orders page shows error state when list api fails", async ({ page }) => {
+  await page.route("**://localhost:5003/orders", async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: "{}",
+    })
+  })
+
+  await page.goto("/orders")
+  await expect(page.getByText("APIエラーが発生しました (500)")).toBeVisible()
+})

--- a/apps/web/src/features/order/orderStatus.test.ts
+++ b/apps/web/src/features/order/orderStatus.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { getOrderStatusMeta } from "./orderStatus"
+
+describe("orderStatus", () => {
+  it("returns localized label for known status", () => {
+    expect(getOrderStatusMeta("accepted").label).toBe("受付")
+    expect(getOrderStatusMeta("shipped").label).toBe("出荷")
+    expect(getOrderStatusMeta("completed").label).toBe("完了")
+    expect(getOrderStatusMeta("cancelled").label).toBe("キャンセル")
+  })
+
+  it("falls back to raw status for unknown status", () => {
+    const meta = getOrderStatusMeta("unknown-status")
+    expect(meta.label).toBe("unknown-status")
+    expect(meta.className).toContain("zinc")
+  })
+})

--- a/apps/web/src/features/order/orderStatus.ts
+++ b/apps/web/src/features/order/orderStatus.ts
@@ -1,0 +1,30 @@
+export type OrderStatusMeta = {
+  label: string
+  className: string
+}
+
+const STATUS_META: Record<string, OrderStatusMeta> = {
+  accepted: {
+    label: "受付",
+    className: "border-sky-400/40 bg-sky-950/40 text-sky-200",
+  },
+  shipped: {
+    label: "出荷",
+    className: "border-amber-400/40 bg-amber-950/40 text-amber-200",
+  },
+  completed: {
+    label: "完了",
+    className: "border-emerald-400/40 bg-emerald-950/40 text-emerald-200",
+  },
+  cancelled: {
+    label: "キャンセル",
+    className: "border-rose-400/40 bg-rose-950/40 text-rose-200",
+  },
+}
+
+export function getOrderStatusMeta(status: string): OrderStatusMeta {
+  return STATUS_META[status] ?? {
+    label: status,
+    className: "border-zinc-500/45 bg-zinc-800/70 text-zinc-200",
+  }
+}

--- a/apps/web/src/features/order/types.ts
+++ b/apps/web/src/features/order/types.ts
@@ -1,0 +1,13 @@
+export type OrderItemResponse = {
+  productId: string
+  quantity: number
+}
+
+export type OrderResponse = {
+  id: string
+  userId: string
+  status: string
+  createdAtUtc: string
+  updatedAtUtc: string
+  items: OrderItemResponse[]
+}

--- a/apps/web/src/pages/CheckoutPage.tsx
+++ b/apps/web/src/pages/CheckoutPage.tsx
@@ -72,6 +72,7 @@ function CheckoutPage({
           </div>
           <div className="flex items-center gap-2">
             <Button onClick={() => navigate("/products")}>商品一覧へ戻る</Button>
+            <Button onClick={() => navigate("/orders")}>注文履歴</Button>
             <Button onClick={onLogout} variant="ghost">
               ログアウト
             </Button>

--- a/apps/web/src/pages/OrdersPage.tsx
+++ b/apps/web/src/pages/OrdersPage.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import Button from "../components/ui/Button"
+import { getOrderStatusMeta } from "../features/order/orderStatus"
+import type { OrderResponse } from "../features/order/types"
+
+type OrdersPageProps = {
+  onLogout: () => void
+  fetchOrders: () => Promise<OrderResponse[]>
+  fetchOrderById: (orderId: string) => Promise<OrderResponse>
+}
+
+function OrdersPage({ onLogout, fetchOrders, fetchOrderById }: OrdersPageProps) {
+  const navigate = useNavigate()
+  const [orders, setOrders] = useState<OrderResponse[]>([])
+  const [listStatus, setListStatus] = useState<"loading" | "success" | "error">("loading")
+  const [listError, setListError] = useState<string | null>(null)
+  const [selectedOrder, setSelectedOrder] = useState<OrderResponse | null>(null)
+  const [detailStatus, setDetailStatus] = useState<"idle" | "loading" | "success" | "error">("idle")
+  const [detailError, setDetailError] = useState<string | null>(null)
+
+  const loadOrders = useCallback(async () => {
+    setListStatus("loading")
+    setListError(null)
+    setSelectedOrder(null)
+    setDetailStatus("idle")
+    setDetailError(null)
+
+    try {
+      const data = await fetchOrders()
+      setOrders(data)
+      setListStatus("success")
+    } catch (err) {
+      setListStatus("error")
+      setListError(err instanceof Error ? err.message : "注文履歴の取得に失敗しました。")
+    }
+  }, [fetchOrders])
+
+  const loadOrderDetail = useCallback(async (orderId: string) => {
+    setDetailStatus("loading")
+    setDetailError(null)
+
+    try {
+      const data = await fetchOrderById(orderId)
+      setSelectedOrder(data)
+      setDetailStatus("success")
+    } catch (err) {
+      setDetailStatus("error")
+      setDetailError(err instanceof Error ? err.message : "注文詳細の取得に失敗しました。")
+    }
+  }, [fetchOrderById])
+
+  useEffect(() => {
+    const timerId = window.setTimeout(() => {
+      void loadOrders()
+    }, 0)
+
+    return () => window.clearTimeout(timerId)
+  }, [loadOrders])
+
+  return (
+    <main className="min-h-screen bg-zinc-900 text-zinc-100">
+      <header className="sticky top-0 z-20 border-b border-zinc-700/50 bg-zinc-900/85 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <p className="text-sm text-zinc-400">Orders</p>
+            <h1 className="text-lg font-semibold text-white">注文履歴</h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button onClick={() => navigate("/products")}>商品一覧</Button>
+            <Button onClick={() => navigate("/checkout")}>注文ページ</Button>
+            <Button onClick={onLogout} variant="ghost">
+              ログアウト
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto grid max-w-6xl gap-6 px-6 py-8 lg:grid-cols-[1.3fr_1fr]">
+        <section className="rounded-2xl border border-zinc-600/45 bg-zinc-800/55 p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-base font-semibold text-white">注文一覧</h2>
+            <Button onClick={() => void loadOrders()}>再読み込み</Button>
+          </div>
+
+          {listStatus === "loading" && (
+            <p className="rounded-xl border border-zinc-600/45 bg-zinc-900/55 px-4 py-3 text-sm text-zinc-300">
+              注文履歴を読み込み中...
+            </p>
+          )}
+
+          {listStatus === "error" && listError && (
+            <p className="rounded-xl border border-red-500/40 bg-red-950/40 px-4 py-3 text-sm text-red-200">
+              {listError}
+            </p>
+          )}
+
+          {listStatus === "success" && orders.length === 0 && (
+            <p className="rounded-xl border border-zinc-600/45 bg-zinc-900/55 px-4 py-3 text-sm text-zinc-300">
+              注文履歴はまだありません。
+            </p>
+          )}
+
+          {listStatus === "success" && orders.length > 0 && (
+            <ul className="space-y-3">
+              {orders.map((order) => {
+                const statusMeta = getOrderStatusMeta(order.status)
+                return (
+                  <li key={order.id} className="rounded-xl border border-zinc-600/45 bg-zinc-900/55 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="text-xs text-zinc-400">OrderId: {order.id}</p>
+                      <span className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusMeta.className}`}>
+                        {statusMeta.label}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm text-zinc-300">
+                      {new Date(order.createdAtUtc).toLocaleString("ja-JP")}
+                    </p>
+                    <p className="mt-1 text-sm text-zinc-400">明細: {order.items.length}件</p>
+                    <Button className="mt-3" onClick={() => void loadOrderDetail(order.id)}>
+                      詳細を表示
+                    </Button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </section>
+
+        <aside className="rounded-2xl border border-zinc-600/45 bg-zinc-800/55 p-5">
+          <h2 className="text-base font-semibold text-white">注文詳細</h2>
+
+          {detailStatus === "idle" && (
+            <p className="mt-3 text-sm text-zinc-300">一覧から注文を選択すると詳細を表示します。</p>
+          )}
+
+          {detailStatus === "loading" && (
+            <p className="mt-3 rounded-xl border border-zinc-600/45 bg-zinc-900/55 px-4 py-3 text-sm text-zinc-300">
+              注文詳細を読み込み中...
+            </p>
+          )}
+
+          {detailStatus === "error" && detailError && (
+            <p className="mt-3 rounded-xl border border-red-500/40 bg-red-950/40 px-4 py-3 text-sm text-red-200">
+              {detailError}
+            </p>
+          )}
+
+          {detailStatus === "success" && selectedOrder && (
+            <div className="mt-3 space-y-3">
+              <div>
+                <p className="text-xs text-zinc-400">OrderId</p>
+                <p className="text-sm text-zinc-100">{selectedOrder.id}</p>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-400">ステータス</p>
+                <p className="text-sm text-zinc-100">{getOrderStatusMeta(selectedOrder.status).label}</p>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-400">明細</p>
+                <ul className="mt-2 space-y-2">
+                  {selectedOrder.items.map((item) => (
+                    <li key={item.productId} className="rounded-lg border border-zinc-600/45 bg-zinc-900/55 px-3 py-2 text-sm text-zinc-200">
+                      ProductId: {item.productId} / 数量: {item.quantity}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
+        </aside>
+      </div>
+    </main>
+  )
+}
+
+export default OrdersPage

--- a/apps/web/src/pages/ProductsPage.tsx
+++ b/apps/web/src/pages/ProductsPage.tsx
@@ -122,6 +122,7 @@ function ProductsPage({
           </div>
 
           <div className="relative flex items-center gap-3">
+            <Button onClick={() => navigate("/orders")}>注文履歴</Button>
             <Button onClick={() => navigate("/checkout")}>カート ({cartCount})</Button>
             <Button aria-label="通知" size="icon" className="relative">
               <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current" aria-hidden="true">

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -4,8 +4,10 @@ import { postAuthLogin, type LoginRequest, type PostAuthLoginResponse } from "..
 import { client } from "../api/identity/client.gen"
 import type { CartItem, CategoryResponse, ProductListResponse, ProductResponse } from "../features/catalog/types"
 import type { CheckoutExecutionResult, CheckoutLineResult } from "../features/order/checkoutSummary"
+import type { OrderResponse } from "../features/order/types"
 import CheckoutPage from "../pages/CheckoutPage"
 import LoginPage from "../pages/LoginPage"
+import OrdersPage from "../pages/OrdersPage"
 import ProductDetailPage from "../pages/ProductDetailPage"
 import ProductsPage from "../pages/ProductsPage"
 
@@ -117,6 +119,45 @@ function AppRouter() {
       return (await response.json()) as ProductResponse
     },
     [catalogBaseUrl, mapApiError],
+  )
+
+  const fetchOrders = useCallback(async (): Promise<OrderResponse[]> => {
+    if (!token) {
+      throw new Error("JWT がありません。再ログインしてください。")
+    }
+
+    const response = await fetch(`${orderBaseUrl}/orders`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(mapApiError(response.status))
+    }
+
+    return (await response.json()) as OrderResponse[]
+  }, [mapApiError, orderBaseUrl, token])
+
+  const fetchOrderById = useCallback(
+    async (orderId: string): Promise<OrderResponse> => {
+      if (!token) {
+        throw new Error("JWT がありません。再ログインしてください。")
+      }
+
+      const response = await fetch(`${orderBaseUrl}/orders/${orderId}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(mapApiError(response.status))
+      }
+
+      return (await response.json()) as OrderResponse
+    },
+    [mapApiError, orderBaseUrl, token],
   )
 
   const handleAddToCart = (product: ProductResponse) => {
@@ -351,6 +392,16 @@ function AppRouter() {
               onCartQuantityChange={handleCartQuantityChange}
               onCheckout={handleCheckout}
             />
+          ) : (
+            <Navigate to="/login" replace />
+          )
+        }
+      />
+      <Route
+        path="/orders"
+        element={
+          token ? (
+            <OrdersPage onLogout={handleLogout} fetchOrders={fetchOrders} fetchOrderById={fetchOrderById} />
           ) : (
             <Navigate to="/login" replace />
           )

--- a/docs/chapter-13-order-history-status.md
+++ b/docs/chapter-13-order-history-status.md
@@ -1,0 +1,79 @@
+# 第13章: 注文履歴と注文状態表示
+
+第12章でチェックアウト専用ページを実装しました。  
+第13章では、購入後に注文状況を追えるように `注文履歴ページ` を追加します。
+
+## 13-1. この章のゴール
+
+- 注文履歴一覧を表示できる
+- 注文詳細でステータスと明細を確認できる
+- 空状態とAPIエラー状態を表示できる
+- 単体テストとE2Eテストを追加する
+
+## 13-2. 実装内容
+
+### ルーティング追加
+
+- `GET /orders` を使う `OrdersPage` を追加
+- 画面ルート: `/orders`
+- `Products` と `Checkout` のヘッダーから遷移可能
+
+### 一覧と詳細
+
+- 一覧カードに以下を表示
+  - OrderId
+  - 作成日時
+  - ステータス（受付/出荷/完了/キャンセル）
+  - 明細件数
+- `詳細を表示` で `GET /orders/{id}` を実行
+- 右カラムに注文詳細（ステータス・明細）を表示
+
+### ステータス表示の整理
+
+`orderStatus.ts` で API ステータス値を画面表示用に変換します。
+
+- `accepted` -> `受付`
+- `shipped` -> `出荷`
+- `completed` -> `完了`
+- `cancelled` -> `キャンセル`
+
+未知ステータスは文字列をそのまま表示します。
+
+### 空状態/エラー状態
+
+- 一覧0件: `注文履歴はまだありません。`
+- 一覧API失敗: `APIエラーが発生しました (xxx)`
+- 詳細取得失敗: 赤系アラートで表示
+
+## 13-3. 追加/更新ファイル
+
+追加:
+
+- `apps/web/src/pages/OrdersPage.tsx`
+- `apps/web/src/features/order/types.ts`
+- `apps/web/src/features/order/orderStatus.ts`
+- `apps/web/src/features/order/orderStatus.test.ts`
+- `apps/web/e2e/orders.spec.ts`
+
+更新:
+
+- `apps/web/src/routes/AppRouter.tsx`
+- `apps/web/src/pages/ProductsPage.tsx`
+- `apps/web/src/pages/CheckoutPage.tsx`
+
+## 13-4. 動作確認ポイント
+
+- `/orders` で注文履歴一覧が表示される
+- ステータスが日本語ラベルで識別できる
+- 一覧から詳細表示で明細確認できる
+- 一覧API失敗時にエラー表示される
+
+## 13-5. テスト
+
+- Frontend Lint: `npm run lint`
+- Frontend Unit Test: `npm run test:unit`
+- Frontend E2E: `npm run test:e2e`
+
+## 13-6. 関連Issue
+
+- https://github.com/Kaito-Nishihara/inventory-management/issues/14


### PR DESCRIPTION
## 概要
第13章として、注文履歴の参照機能を追加しました。ユーザーが購入後の注文状態を追跡できるようにしています。

## 実装した機能
- /orders 画面を追加（注文一覧 + 注文詳細）
- 注文ステータス表示を実装（受付 / 出荷 / 完了 / キャンセル）
- 一覧0件時の空状態表示
- API失敗時のエラー表示（一覧/詳細）
- Products/Checkout ヘッダーから注文履歴へ遷移導線を追加

## テスト
- Unit: orderStatus のステータス表示マッピング
- E2E: orders.spec.ts
  - 注文履歴表示 + 詳細表示
  - 一覧API失敗時のエラー表示

## ドキュメント
- docs/chapter-13-order-history-status.md を追加

## 補足
- Storybook関連の変更はこのPRに含めていません（別ブランチで対応）

Closes #14